### PR TITLE
Use "cask" instead of "brew" for  bundle examle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Or, in a [`brew bundle`](https://github.com/Homebrew/homebrew-bundle) `Brewfile`
 
 ```ruby
 tap "mhaeuser/mhaeuser"
-brew "<formula>"
+cask "<formula>"
 ```
 
 ## Documentation


### PR DESCRIPTION
Battery-Toolk it is a cask, so brew "battery-toolkit" will fail, the correct way to install via a brew bundle is:

```
tap "mhaeuser/mhaeuser"
cask "battery-toolkit"
```